### PR TITLE
Separate workflow related config from servicenow instance config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ service_now:
   instance_name: "<instance name>"
   user_name: "<user>"
   password: "<password>"
+
+workflow:
   # Name of an existing ServiceNow table field that will be used as a key to uniquely reference an alert group in incident management workflow
   incident_group_key_field: "<incident table field>"
   # ID if the incident states for which existing incident will not be updated on firing alert group; leading to the creation of a new incident

--- a/config/servicenow_example.yml
+++ b/config/servicenow_example.yml
@@ -2,6 +2,8 @@ service_now:
   instance_name: "<instance name>"
   user_name: "<user>"
   password: "<password>"
+
+workflow:
   # Name of an existing ServiceNow table field that will be used as a key to uniquely reference an alert group in incident management workflow
   incident_group_key_field: "<incident table field>"
   # ID if the incident states for which existing incident will not be updated on firing alert group; leading to the creation of a new incident

--- a/main.go
+++ b/main.go
@@ -28,14 +28,19 @@ var (
 // Config - ServiceNow webhook configuration
 type Config struct {
 	ServiceNow      ServiceNowConfig      `yaml:"service_now"`
+	Workflow        WorkflowConfig        `yaml:"workflow"`
 	DefaultIncident DefaultIncidentConfig `yaml:"default_incident"`
 }
 
 // ServiceNowConfig - ServiceNow instance configuration
 type ServiceNowConfig struct {
-	InstanceName          string        `yaml:"instance_name"`
-	UserName              string        `yaml:"user_name"`
-	Password              string        `yaml:"password"`
+	InstanceName string `yaml:"instance_name"`
+	UserName     string `yaml:"user_name"`
+	Password     string `yaml:"password"`
+}
+
+// WorkflowConfig - Incident workflow configuration
+type WorkflowConfig struct {
 	IncidentGroupKeyField string        `yaml:"incident_group_key_field"`
 	NoUpdateStates        []json.Number `yaml:"no_update_states"`
 }
@@ -146,8 +151,8 @@ func loadConfig(configFile string) (Config, error) {
 	}
 
 	// Load internal state from config
-	noUpdateStates = make(map[json.Number]bool, len(config.ServiceNow.NoUpdateStates))
-	for _, s := range config.ServiceNow.NoUpdateStates {
+	noUpdateStates = make(map[json.Number]bool, len(config.Workflow.NoUpdateStates))
+	for _, s := range config.Workflow.NoUpdateStates {
 		noUpdateStates[s] = true
 	}
 
@@ -157,7 +162,7 @@ func loadConfig(configFile string) (Config, error) {
 
 func loadSnClient() (ServiceNow, error) {
 	var err error
-	serviceNow, err = NewServiceNowClient(config.ServiceNow.InstanceName, config.ServiceNow.UserName, config.ServiceNow.Password, config.ServiceNow.IncidentGroupKeyField)
+	serviceNow, err = NewServiceNowClient(config.ServiceNow.InstanceName, config.ServiceNow.UserName, config.ServiceNow.Password, config.Workflow.IncidentGroupKeyField)
 	if err != nil {
 		return serviceNow, err
 	}
@@ -170,7 +175,7 @@ func onAlertGroup(data template.Data) error {
 		data.Status, data.GroupLabels, data.CommonLabels, data.CommonAnnotations)
 
 	getParams := map[string]string{
-		config.ServiceNow.IncidentGroupKeyField: getGroupKey(data),
+		config.Workflow.IncidentGroupKeyField: getGroupKey(data),
 	}
 
 	incidents, err := serviceNow.GetIncidents(getParams)


### PR DESCRIPTION
Workflow related config is separated from servicenow instance config for 2 reasons:
1) These are two conceptual aspects of the config
2) It will ease automated configuration as the servicenow instance config is a more sensitive part