### PR TITLE
Bugfix/long group key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [Prometheus AlertManager](https://github.com/prometheus/alertmanager) webhook 
 The supported authentication to ServiceNow is through a service account (basic authentication through HTTPS).
 
 ### Creation of incident by alert group
-One incident is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. This avoid spamming ServiceNow with incidents when a huge system failure occurs, and still provide a very flexible mechanism to group alerts in one incident.
+One incident is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. This avoid spamming ServiceNow with incidents when a huge system failure occurs, and still provide a very flexible mechanism to group alerts in one incident. The ServiceNow field used to hold the group key is configurable through the `incident_group_key_field` property and will contain a hash of the group key.
 
 ### Incident management workflow
 The supported incident workflow is the following:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ service_now:
   password: "<password>"
 
 workflow:
-  # Name of an existing ServiceNow table field that will be used as a key to uniquely reference an alert group in incident management workflow
+  # Name of an existing ServiceNow table field that will be used as a key to uniquely reference an alert group in incident management workflow. 
+  # This field must accept a minimum of 32 characters.
   incident_group_key_field: "<incident table field>"
   # ID if the incident states for which existing incident will not be updated on firing alert group; leading to the creation of a new incident
   no_update_states: [6,7]

--- a/config/servicenow_example.yml
+++ b/config/servicenow_example.yml
@@ -4,7 +4,8 @@ service_now:
   password: "<password>"
 
 workflow:
-  # Name of an existing ServiceNow table field that will be used as a key to uniquely reference an alert group in incident management workflow
+  # Name of an existing ServiceNow table field that will be used as a key to uniquely reference an alert group in incident management workflow. 
+  # This field must accept a minimum of 32 characters.
   incident_group_key_field: "<incident table field>"
   # ID if the incident states for which existing incident will not be updated on firing alert group; leading to the creation of a new incident
   no_update_states: [6,7]

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/common/log"
+
+	"crypto/md5"
 )
 
 var (
@@ -314,5 +316,6 @@ func filterForUpdate(incident Incident) Incident {
 }
 
 func getGroupKey(data template.Data) string {
-	return fmt.Sprintf("%v", data.GroupLabels.SortedPairs())
+	hash := md5.Sum([]byte(fmt.Sprintf("%v", data.GroupLabels.SortedPairs())))
+	return fmt.Sprintf("%x", hash)
 }


### PR DESCRIPTION
A fixed length key will solve cases where the configured group key length is larger than the maximum ServiceNow field length used to store the key.