### PR TITLE
Add Common Fields for Incident Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ default_incident:
   # Urgency: Speed at which the business expects the incident to be resolved
   # Common values: 1 (High), 2 (Medium), 3 (Low)
   urgency: "<urgency value>"
+  common_fields: {}
+    #u_issue_type: "data_issue"
+    #u_affected_user: "User Name"
+    #business_service: "Service-Name"
+    #u_environment: "prod"
+    #u_source: "SomeSource"
 ```
 
 ### AlertManager config

--- a/config/servicenow_example.yml
+++ b/config/servicenow_example.yml
@@ -41,3 +41,9 @@ default_incident:
   # Urgency: Speed at which the business expects the incident to be resolved
   # Common values: 1 (High), 2 (Medium), 3 (Low)
   urgency: "{{.CommonAnnotations.urgency}}"
+  common_fields: {}
+    #u_issue_type: "data_issue"
+    #u_affected_user: "User Name"
+    #business_service: "Service-Name"
+    #u_environment: "prod"
+    #u_source: "SomeSource"

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ type DefaultIncidentConfig struct {
 	ShortDescription string `yaml:"short_description"`
 	SubCategory      string `yaml:"subcategory"`
 	Urgency          string `yaml:"urgency"`
-	CommonFields     map[string]string `yaml:common_fields`
+	CommonFields     map[string]string `yaml:"common_fields"`
 }
 
 // JSONResponse is the Webhook http response

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ type DefaultIncidentConfig struct {
 	ShortDescription string `yaml:"short_description"`
 	SubCategory      string `yaml:"subcategory"`
 	Urgency          string `yaml:"urgency"`
+	CommonFields     map[string]string `yaml:common_fields`
 }
 
 // JSONResponse is the Webhook http response
@@ -284,6 +285,9 @@ func alertGroupToIncident(data template.Data) (Incident, error) {
 		"subcategory":                         config.DefaultIncident.SubCategory,
 		"urgency":                             config.DefaultIncident.Urgency,
 	}
+        for k,v := range config.DefaultIncident.CommonFields {
+                incident[k] = v
+        }
 
 	applyIncidentTemplate(incident, data)
 	validateIncident(incident)


### PR DESCRIPTION
This PR Implements support of additional Incident fields defined by config file
Example:
```
  common_fields:
    u_issue_type: "data_issue"
    u_affected_user: "User Name"
    business_service: "Service-Name"
    u_environment: "prod"
    u_source: "SomeSource"
```
and any other additional fields