### PR TITLE
Add environment variable overrides and default config to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN make build
 FROM quay.io/prometheus/busybox:glibc AS app
 LABEL maintainer="FXinnovation CloudToolDevelopment <CloudToolDevelopment@fxinnovation.com>"
 COPY --from=builder /go/src/github.com/FXinnovation/alertmanager-webhook-servicenow/alertmanager-webhook-servicenow /bin/alertmanager-webhook-servicenow
+COPY --from=builder /go/src/github.com/FXinnovation/alertmanager-webhook-servicenow/config/servicenow_example.yml /config/servicenow.yml
 
+VOLUME [ "/config" ]
 EXPOSE      9877
 WORKDIR /
 ENTRYPOINT  [ "/bin/alertmanager-webhook-servicenow" ]

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -166,6 +167,8 @@ func loadConfigContent(configData []byte) (Config, error) {
 		return config, err
 	}
 
+	loadEnvVars(&config)
+
 	err = config.validate()
 	if err != nil {
 		return config, err
@@ -194,6 +197,21 @@ func loadConfig(configFile string) (Config, error) {
 	}
 
 	return loadConfigContent(configData)
+}
+
+func loadEnvVars(c *Config) {
+	if instanceName, ok := os.LookupEnv("SERVICENOW_INSTANCE_NAME"); ok {
+		(*c).ServiceNow.InstanceName = instanceName
+	}
+	if userName, ok := os.LookupEnv("SERVICENOW_USERNAME"); ok {
+		(*c).ServiceNow.UserName = userName
+	}
+	if password, ok := os.LookupEnv("SERVICENOW_PASSWORD"); ok {
+		(*c).ServiceNow.Password = password
+	}
+	if incidentField, ok := os.LookupEnv("SERVICENOW_INCIDENT_FIELD"); ok {
+		(*c).Workflow.IncidentGroupKeyField = incidentField
+	}
 }
 
 func loadSnClient() (ServiceNow, error) {

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func loadEnvVars(c *Config) {
 	if password, ok := os.LookupEnv("SERVICENOW_PASSWORD"); ok {
 		(*c).ServiceNow.Password = password
 	}
-	if incidentField, ok := os.LookupEnv("SERVICENOW_INCIDENT_FIELD"); ok {
+	if incidentField, ok := os.LookupEnv("SERVICENOW_INCIDENT_GROUP_KEY_FIELD"); ok {
 		(*c).Workflow.IncidentGroupKeyField = incidentField
 	}
 }


### PR DESCRIPTION
I plan to run this in Kubernetes and it would be easier to manage the ServiceNow credentials as environment variables rather than in the config file so I can avoid putting them in source control. I've set it up so the presence of environment variables overrides what is in the config file, and by default the Docker image will use the servicenow_example.yml file as its config file so no setup is required for quick testing. If you're okay with these changes, I'll add documentation as well.