### PR TITLE
Added a table name for the ServiceNow Api calls, via configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ service_now:
   # Mandatory. A user with permissions to read and update ServiceNow incidents.
   user_name: "<user>"
   password: "<password>"
+  table_name: "<table_name>"
 
 workflow:
   # Mandatory. Name of an existing ServiceNow incident field that will be used to hold the hashed key that uniquely reference an alert group in the incident management workflow.

--- a/config/servicenow_example.yml
+++ b/config/servicenow_example.yml
@@ -2,6 +2,7 @@ service_now:
   instance_name: "CHANGE_ME"
   user_name: "CHANGE_ME"
   password: "CHANGE_ME"
+  table_name: "incident"
 
 workflow:
   incident_group_key_field: "CHANGE_ME"

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ type ServiceNowConfig struct {
 	InstanceName string `yaml:"instance_name"`
 	UserName     string `yaml:"user_name"`
 	Password     string `yaml:"password"`
+	TableName	 string `yaml:"table_name"`
 }
 
 // WorkflowConfig - Incident workflow configuration
@@ -304,7 +305,7 @@ func onAlertGroup(data template.Data) error {
 		config.Workflow.IncidentGroupKeyField: getGroupKey(data),
 	}
 
-	existingIncidents, err := serviceNow.GetIncidents(getParams)
+	existingIncidents, err := serviceNow.GetIncidents(config.ServiceNow.TableName,getParams)
 	if err != nil {
 		serviceNowError.Inc()
 		return err
@@ -344,13 +345,13 @@ func onFiringGroup(data template.Data, updatableIncident Incident) error {
 
 	if updatableIncident == nil {
 		log.Infof("Found no updatable incident for firing alert group key: %s", getGroupKey(data))
-		if _, err := serviceNow.CreateIncident(incidentCreateParam); err != nil {
+		if _, err := serviceNow.CreateIncident(config.ServiceNow.TableName, incidentCreateParam); err != nil {
 			serviceNowError.Inc()
 			return err
 		}
 	} else {
 		log.Infof("Found updatable incident (%s), with state %s, for firing alert group key: %s", updatableIncident.GetNumber(), updatableIncident.GetState(), getGroupKey(data))
-		if _, err := serviceNow.UpdateIncident(incidentUpdateParam, updatableIncident.GetSysID()); err != nil {
+		if _, err := serviceNow.UpdateIncident(config.ServiceNow.TableName, incidentUpdateParam, updatableIncident.GetSysID()); err != nil {
 			serviceNowError.Inc()
 			return err
 		}
@@ -370,7 +371,7 @@ func onResolvedGroup(data template.Data, updatableIncident Incident) error {
 		log.Infof("Found no updatable incident for resolved alert group key: %s. No incident will be created/updated.", getGroupKey(data))
 	} else {
 		log.Infof("Found updatable incident (%s), with state %s, for resolved alert group key: %s", updatableIncident.GetNumber(), updatableIncident.GetState(), getGroupKey(data))
-		if _, err := serviceNow.UpdateIncident(incidentUpdateParam, updatableIncident.GetSysID()); err != nil {
+		if _, err := serviceNow.UpdateIncident(config.ServiceNow.TableName, incidentUpdateParam, updatableIncident.GetSysID()); err != nil {
 			serviceNowError.Inc()
 			return err
 		}

--- a/servicenow.go
+++ b/servicenow.go
@@ -62,9 +62,9 @@ func (ir IncidentsResponse) GetResults() []Incident {
 
 // ServiceNow interface
 type ServiceNow interface {
-	CreateIncident(incidentParam Incident) (Incident, error)
-	GetIncidents(params map[string]string) ([]Incident, error)
-	UpdateIncident(incidentParam Incident, sysID string) (Incident, error)
+	CreateIncident(tableName string, incidentParam Incident) (Incident, error)
+	GetIncidents(tableName string, params map[string]string) ([]Incident, error)
+	UpdateIncident(tableName string, incidentParam Incident, sysID string) (Incident, error)
 }
 
 // ServiceNowClient is the interface to a ServiceNow instance
@@ -176,7 +176,7 @@ func (snClient *ServiceNowClient) doRequest(req *http.Request) ([]byte, error) {
 }
 
 // CreateIncident will create an incident in ServiceNow from a given Incident, and return the created incident
-func (snClient *ServiceNowClient) CreateIncident(incidentParam Incident) (Incident, error) {
+func (snClient *ServiceNowClient) CreateIncident(tableName string, incidentParam Incident) (Incident, error) {
 	log.Info("Create a ServiceNow incident")
 
 	postBody, err := json.Marshal(incidentParam)
@@ -185,7 +185,7 @@ func (snClient *ServiceNowClient) CreateIncident(incidentParam Incident) (Incide
 		return nil, err
 	}
 
-	response, err := snClient.create("incident", postBody)
+	response, err := snClient.create(tableName, postBody)
 	if err != nil {
 		log.Errorf("Error while creating the incident. %s", err)
 		return nil, err
@@ -205,9 +205,9 @@ func (snClient *ServiceNowClient) CreateIncident(incidentParam Incident) (Incide
 }
 
 // GetIncidents will retrieve an incident from ServiceNow
-func (snClient *ServiceNowClient) GetIncidents(params map[string]string) ([]Incident, error) {
+func (snClient *ServiceNowClient) GetIncidents(tableName string, params map[string]string) ([]Incident, error) {
 	log.Infof("Get ServiceNow incidents with params: %v", params)
-	response, err := snClient.get("incident", params)
+	response, err := snClient.get(tableName, params)
 
 	if err != nil {
 		log.Errorf("Error while getting the incident. %s", err)
@@ -225,7 +225,7 @@ func (snClient *ServiceNowClient) GetIncidents(params map[string]string) ([]Inci
 }
 
 // UpdateIncident will update an incident in ServiceNow from a given Incident, and return the updated incident
-func (snClient *ServiceNowClient) UpdateIncident(incidentParam Incident, sysID string) (Incident, error) {
+func (snClient *ServiceNowClient) UpdateIncident(tableName string, incidentParam Incident, sysID string) (Incident, error) {
 	log.Infof("Update %v field(s) of ServiceNow incident with id : %s", len(incidentParam), sysID)
 
 	postBody, err := json.Marshal(incidentParam)
@@ -234,7 +234,7 @@ func (snClient *ServiceNowClient) UpdateIncident(incidentParam Incident, sysID s
 		return nil, err
 	}
 
-	response, err := snClient.update("incident", postBody, sysID)
+	response, err := snClient.update(tableName, postBody, sysID)
 	if err != nil {
 		log.Errorf("Error while updating the incident. %s", err)
 		return nil, err

--- a/servicenow_test.go
+++ b/servicenow_test.go
@@ -90,7 +90,7 @@ func TestCreateIncident_OK(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	incident, err := snClient.CreateIncident(basicIncidentParam)
+	incident, err := snClient.CreateIncident("incident", basicIncidentParam)
 
 	if err != nil {
 		t.Errorf("Error occured on CreateIncident: %s", err)
@@ -124,7 +124,7 @@ func TestCreateIncident_OK_No_AG(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	incident, err := snClient.CreateIncident(basicIncidentParam)
+	incident, err := snClient.CreateIncident("incident", basicIncidentParam)
 
 	if err != nil {
 		t.Errorf("Error occured on CreateIncident: %s", err)
@@ -151,7 +151,7 @@ func TestCreateIncident_IncidentMarshallError(t *testing.T) {
 	}
 
 	// Cause an error by using invalid incident
-	_, err = snClient.CreateIncident(wrongIncidentParam)
+	_, err = snClient.CreateIncident("incident", wrongIncidentParam)
 
 	if err == nil {
 		t.Errorf("Expected an error, got none")
@@ -167,7 +167,7 @@ func TestCreateIncident_CreateRequestError(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	_, err = snClient.CreateIncident(basicIncidentParam)
+	_, err = snClient.CreateIncident("incident", basicIncidentParam)
 
 	if err == nil {
 		t.Errorf("Expected an error, got none")
@@ -187,7 +187,7 @@ func TestCreateIncident_DoRequestError(t *testing.T) {
 
 	// Cause an error by closing the server
 	ts.Close()
-	_, err = snClient.CreateIncident(basicIncidentParam)
+	_, err = snClient.CreateIncident("incident", basicIncidentParam)
 
 	if err == nil {
 		t.Errorf("Expected an error, got none")
@@ -209,7 +209,7 @@ func TestCreateIncident_InternalServerError(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	_, err = snClient.CreateIncident(basicIncidentParam)
+	_, err = snClient.CreateIncident("incident", basicIncidentParam)
 
 	if err == nil {
 		t.Errorf("Expected an error, got none")
@@ -234,7 +234,7 @@ func TestGetIncidents_OK(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	incidents, err := snClient.GetIncidents(nil)
+	incidents, err := snClient.GetIncidents("incident", nil)
 	if err != nil {
 		t.Errorf("Error occured on CreateIncident: %s", err)
 	}
@@ -256,7 +256,7 @@ func TestGetIncidents_CreateRequestError(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	_, err = snClient.GetIncidents(nil)
+	_, err = snClient.GetIncidents("incident", nil)
 
 	if err == nil {
 		t.Errorf("Expected an error, got none")
@@ -283,7 +283,7 @@ func TestUpdateIncident_OK(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	incident, err := snClient.UpdateIncident(basicIncidentParam, "my_sys_id")
+	incident, err := snClient.UpdateIncident("incident", basicIncidentParam, "my_sys_id")
 
 	if err != nil {
 		t.Errorf("Error occured on UpdateIncident: %s", err)
@@ -306,7 +306,7 @@ func TestUpdateIncident_CreateRequestError(t *testing.T) {
 		t.Errorf("Error occured on NewServiceNowClient: %s", err)
 	}
 
-	_, err = snClient.UpdateIncident(basicIncidentParam, "my_sys_id")
+	_, err = snClient.UpdateIncident("incident", basicIncidentParam, "my_sys_id")
 
 	if err == nil {
 		t.Errorf("Expected an error, got none")


### PR DESCRIPTION
We are using a new version of service now and this one uses the sn_customerservice_case table besides incident. I added a field in the configuration so that we can use the table name in the calls to the SN API.
Please feel free to give some ideas if the implementation is missing something.