### PR TITLE
feat: Pass the updatable incident to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ The supported incident workflow is the following:
 - Update an existing incident if it is in a state where update is allowed (same
   configuration as above in the webhook). Incident fields to be updated is also
   configurable.
+- Allow to re-use fields from the incident to be updated. If a human has changed 
+  some field of the incident, you can use `.UpdatableIncident.[field]` in your
+  string template.
 
 Note that when an incident is updated, configured data fields are updated (e.g.:
 comments), but incident state is not changed. In the future, an optional

--- a/main_test.go
+++ b/main_test.go
@@ -285,7 +285,8 @@ func TestWebhookHandler_InternalServerError(t *testing.T) {
 func TestApplyTemplate_emptyText(t *testing.T) {
 	data := template.Data{}
 	text := ""
-	got, err := applyTemplate("name", text, data)
+	updatableIncident := Incident{}
+	got, err := applyTemplate("name", text, data, updatableIncident)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,8 +303,9 @@ func TestApplyTemplate_OK(t *testing.T) {
 			"error": "my error",
 		},
 	}
+	updatableIncident := Incident{}
 	text := "Status is {{.Status}} and error is {{.CommonAnnotations.error}}"
-	got, err := applyTemplate("name", text, data)
+	got, err := applyTemplate("name", text, data, updatableIncident)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +325,8 @@ func TestApplyIncidentTemplate_Range(t *testing.T) {
 	incident := Incident{
 		"description": "{{ range $key, $val := .CommonAnnotations}}{{ $key }}:{{ $val }} {{end}}",
 	}
-	applyIncidentTemplate(incident, data)
+	updatableIncident := Incident{}
+	applyIncidentTemplate(incident, data, updatableIncident)
 
 	got := incident["description"]
 	want := "error:a warning:b "


### PR DESCRIPTION
This will allow users to re-use values of fields in their templates to
not overwrite human putted values.